### PR TITLE
Improve validator script, exception message and CI

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -1,0 +1,44 @@
+name: CI
+
+on: [push, pull_request]
+
+jobs:
+  run:
+    runs-on: ${{ matrix.operating-system }}
+    strategy:
+      matrix:
+        operating-system: [ubuntu-latest]
+        php-versions: ['7.3', '7.4', '8.0']
+    name: PHP ${{ matrix.php-versions }} Test on ${{ matrix.operating-system }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v1
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php-versions }}
+          extensions: mbstring, pdo, pdo_mysql, intl, zip
+          coverage: none
+
+      - name: Install Apache2 server
+        run: sudo apt-get update && sudo apt-get install -y apache2
+
+      - name: Check PHP Version
+        run: php -v
+
+      - name: Check Composer Version
+        run: composer -V
+
+      - name: Check PHP Extensions
+        run: php -m
+
+      - name: Validate composer.json and composer.lock
+        run: composer validate
+
+      - name: Install dependencies
+        run: composer install --prefer-dist --no-progress --no-suggest
+
+      - name: Run test suite
+        run: composer test:unit

--- a/bin/validate-htaccess
+++ b/bin/validate-htaccess
@@ -27,10 +27,24 @@
 file=${1:?No configuration file specified.}
 
 # Ensure that httpd is available.
-if ! command -v httpd &> /dev/null; then
-    echo 'Unable to find the httpd binary, is Apache2 installed?' 1>&2
+if [ ! command -v httpd &> /dev/null ] && [! command -v apache2ctl &> /dev/null ] ; then
+    echo 'Unable to find the httpd binary or apache2ctl script, is Apache2 installed?' 1>&2
     exit 2
 fi
+
+command -v httpd &> /dev/null
+exit_code=$?
+
+if [ $exit_code -eq 0 ]; then
+    httpd="httpd"
+fi;
+
+command -v apache2ctl &> /dev/null
+exit_code=$?
+
+if [ $exit_code -eq 0 ]; then
+    httpd="apache2ctl"
+fi;
 
 # Verify the given file actually exists.
 if [ ! -f "$file" ]; then
@@ -40,14 +54,14 @@ fi
 
 # Verify that the current configuration passes; if it doesn't, it won't
 # magically be fixed by throwing more on top of it.
-if ! httpd -t -C "ServerName example.com" 2> /dev/null; then
+if [ ! ${httpd} -t -C 'ServerName example.com' 2> /dev/null ]; then
     echo "The current Apache environment is misconfigured.
 Please resolve these issues before attempting to validate ${file}." 1>&2
     exit 4
 fi
 
 # Get the name of the current configuration file.
-current_config=$(httpd -V \
+current_config=$(${httpd} -V \
     | grep -E -o -e 'SERVER_CONFIG_FILE="(.+)"' \
     | sed 's/SERVER_CONFIG_FILE=//; s/"//g')
 
@@ -57,7 +71,7 @@ cat "$file" > "$tmpfile"
 
 # Now, use Apache to validate itself, injecting $FILE into the current
 # server environment.
-results=$(httpd -t -C "Include ${current_config}" -f "$tmpfile" -C "ServerName example.com" 2>&1)
+results=$(${httpd} -t -C "Include ${current_config}" -f "$tmpfile" -C "ServerName example.com" 2>&1)
 exit_code=$?
 
 # Remove the temp file.

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     ],
     "minimum-stability": "stable",
     "require": {
-        "php": "^5.6||^7.0"
+        "php": "^7.3||^8.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^8.5"

--- a/src/Validator.php
+++ b/src/Validator.php
@@ -93,15 +93,17 @@ class Validator
 
 		$process = proc_open($command, $descriptors, $pipes);
 
-        if (! is_resource($process)) {
-            throw new ValidationException('Unable to open validation process.');
-        }
+		if (! is_resource($process)) {
+			throw new ValidationException('Unable to open validation process.');
+		}
 
-        $exitCode = proc_close($process);
+		$errorMessage = stream_get_contents($pipes[2]);
+		fclose($pipes[2]);
+		$exitCode = proc_close($process);
 
 		if (0 !== $exitCode) {
 			throw new ValidationException(
-				sprintf('Validation errors were encountered: %s', $pipes[2]),
+				sprintf('Validation errors were encountered: %s', $errorMessage),
 				$exitCode
 			);
 		}


### PR DESCRIPTION
# Changed log

- According to the [official PHP doc](https://www.php.net/supported-versions.php), the `php-7.2` version support has been end of life. Using the `php-7.3` version for this package about minimal PHP version requirement.
- Integrating the CI with GitHub Actions.
- Improve `bin/validate-htaccess` script to check whether current binary is available.
  - The `httpd` is available on CentOS, RHEL and Fedora distributions.
  - The `apache2ctl` is available on Debian-based distributions.
- Improving the error message when the exit code presents non-zero code.